### PR TITLE
Add array function

### DIFF
--- a/sql/range_type_functions_95.sql
+++ b/sql/range_type_functions_95.sql
@@ -1,3 +1,21 @@
+CREATE OR REPLACE VIEW range_type AS
+  SELECT
+      rngtypid::regtype AS range_type, rtn.nspname AS range_type_schema, rt.typname AS range_type_name
+      , rngsubtype::regtype AS range_subtype, stn.nspname AS range_subtype_schema, st.typname AS range_subtype_name
+      , rngcollation AS range_type_collation_oid, cn.nspname AS range_type_collation_schema, c.collname AS range_type_collation_name
+      , rngsubopc AS range_type_operator_class_oid, oc.opcname AS range_type_operator_class_name, ocn.nspname AS range_type_operator_class_schema
+      , rngcanonical AS range_type_canonical_function
+      , rngsubdiff::regprocedure AS range_type_subdiff_function
+    FROM pg_range r
+      LEFT JOIN pg_type rt ON rt.oid = rngtypid
+      LEFT JOIN pg_namespace rtn ON rtn.oid = rt.typnamespace
+      LEFT JOIN pg_type st ON st.oid = rngsubtype
+      LEFT JOIN pg_namespace stn ON stn.oid = st.typnamespace
+      LEFT JOIN pg_collation c ON c.oid = rngcollation
+      LEFT JOIN pg_namespace cn ON cn.oid = c.collnamespace
+      LEFT JOIN pg_opclass oc ON oc.oid = rngsubopc
+      LEFT JOIN pg_namespace ocn ON ocn.oid = oc.opcnamespace
+;
 
 create function to_range(low anyelement, high anyelement, bounds text, range anyrange) returns anyrange
 language plpgsql immutable as $$
@@ -142,4 +160,71 @@ begin
 end
 $$;
 
+CREATE OR REPLACE FUNCTION _range_from_array__create(
+  range_type regtype
+) RETURNS regprocedure LANGUAGE plpgsql
+SET search_path FROM CURRENT -- This is necessary for having access to the range_type view
+-- Do NOT set search_path here! Function needs to run with the calling search_path
+AS $_range_from_array__create$
+DECLARE
+  subtype regtype;
+  creation_function regproc;
+
+  c_template CONSTANT text := $template$
+-- This is a template!
+CREATE OR REPLACE FUNCTION range_from_array(
+    a %2$s[] -- 2:range_subtype
+) RETURNS %1$s -- 1:range_type
+LANGUAGE sql IMMUTABLE STRICT
+SET search_path FROM CURRENT -- Make sure search path is same as when creation function was called
+AS $range_from_array$
+SELECT %3$s( -- 3:creation_function
+      min(u)
+      , max(u)
+      , '[]'
+    )
+  FROM unnest(a) u
+$range_from_array$;
+$template$;
+  
+  sql text;
+BEGIN
+  SELECT INTO subtype, creation_function
+      range_subtype
+      , format(
+        $$%1$s(%2$s, %2$s, text)$$
+        , t.range_type -- Blindly assume function has same name as the range type
+        , range_subtype
+      )::regprocedure -- Note that this gets cast back to regproc
+    FROM range_type t
+    WHERE t.range_type = _range_from_array__create.range_type
+  ;
+  IF NOT FOUND THEN
+    /*
+     * Since range_type is of type regtype it must be a valid type, but it
+     * might not be a range type. If we get here either it's not a range type
+     * or our view is broken. :)
+     */
+    RAISE 'type "%" is not a range type', range_type
+      USING ERRCODE = 'undefined_object'
+    ;
+  END IF;
+
+  sql := format(
+    c_template
+    , range_type
+    , subtype
+    , creation_function
+  );
+  RAISE DEBUG 'executing sql: %', sql;
+  EXECUTE sql;
+
+  RETURN format( 'range_from_array(%s[])', subtype )::regprocedure;
+END
+$_range_from_array__create$;
+
+SELECT _range_from_array__create(range_type)
+  FROM range_type
+  WHERE range_type_schema = 'pg_catalog'
+;
 

--- a/test/deps.sql
+++ b/test/deps.sql
@@ -1,3 +1,6 @@
 -- Note: pgTap is loaded by setup.sql
 
--- Add any test dependency statements here
+-- Assume that if this works in a specific schema it'll work anywhere
+\set install_schema range_tools_install
+CREATE SCHEMA :install_schema;
+CREATE EXTENSION range_type_functions WITH SCHEMA :install_schema;

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,234 +1,73 @@
-begin;
 \set ECHO none
-create type textrange as range (subtype = text);
-create type textrange_c as range (subtype = text, collation = "C");
-set datestyle = 'ISO';
-select to_range(4,5,'[]',null::int4range);
- to_range 
-----------
- [4,6)
-(1 row)
-
-select to_range('2015-01-01'::date,'2016-01-1','[)',null::daterange);
-        to_range         
--------------------------
- [2015-01-01,2016-01-01)
-(1 row)
-
-select to_range(4,null::int4range);
- to_range 
-----------
- [4,5)
-(1 row)
-
-select to_range('2015-01-01'::date,null::daterange);
-        to_range         
--------------------------
- [2015-01-01,2015-01-02)
-(1 row)
-
-select element_range_comp(4,'[10,100]'::int4range);
- element_range_comp 
---------------------
-                 -1
-(1 row)
-
-select element_range_comp(10,'[10,100]'::int4range);
- element_range_comp 
---------------------
-                  0
-(1 row)
-
-select element_range_comp(110,'[10,100]'::int4range);
- element_range_comp 
---------------------
-                  1
-(1 row)
-
-select is_singleton('[4,5)'::int4range);
- is_singleton 
---------------
- t
-(1 row)
-
-select is_singleton('[4,5]'::int4range);
- is_singleton 
---------------
- f
-(1 row)
-
+1..9
+ok 1
+ok 2
+ok 3
+ok 4
+ok 5 - element_range_comp('[10,100]'::int4range, 4)
+ok 6 - element_range_comp('[10,100]'::int4range, 10)
+ok 7 - element_range_comp('[10,100]'::int4range, 110)
+ok 8 - is_singleton('[4,5)'::int4range)
+ok 9 - is_singleton('[4,5]'::int4range)
 select range_merge('[4,5]'::int4range,'[9,10]'::int4range);
- range_merge 
--------------
- [4,11)
-(1 row)
-
+[4,11)
 select get_lower_bound_condition_expr('empty'::int4range);
- get_lower_bound_condition_expr 
---------------------------------
- false
-(1 row)
-
+false
 select get_lower_bound_condition_expr('(,)'::int4range);
- get_lower_bound_condition_expr 
---------------------------------
- true
-(1 row)
-
+true
 select get_lower_bound_condition_expr('(4,5]'::int4range);
- get_lower_bound_condition_expr 
---------------------------------
- x >= '5'::integer
-(1 row)
-
+x >= '5'::integer
 select get_lower_bound_condition_expr('(4,5]'::int4range,'y.z');
- get_lower_bound_condition_expr 
---------------------------------
- y.z >= '5'::integer
-(1 row)
-
+y.z >= '5'::integer
 select get_lower_bound_condition_expr('[4,5]'::int4range,'y.z');
- get_lower_bound_condition_expr 
---------------------------------
- y.z >= '4'::integer
-(1 row)
-
+y.z >= '4'::integer
 select get_lower_bound_condition_expr('[4,5]'::int4range,format('%I.%I','my schema','my ColuMnaME'));
-       get_lower_bound_condition_expr       
---------------------------------------------
- "my schema"."my ColuMnaME" >= '4'::integer
-(1 row)
-
+"my schema"."my ColuMnaME" >= '4'::integer
 select get_upper_bound_condition_expr('empty'::int4range);
- get_upper_bound_condition_expr 
---------------------------------
- false
-(1 row)
-
+false
 select get_upper_bound_condition_expr('(,)'::int4range);
- get_upper_bound_condition_expr 
---------------------------------
- true
-(1 row)
-
+true
 select get_upper_bound_condition_expr('[4,5)'::int4range,'y.z');
- get_upper_bound_condition_expr 
---------------------------------
- y.z < '5'::integer
-(1 row)
-
+y.z < '5'::integer
 select get_upper_bound_condition_expr('[4,5]'::int4range,'y.z');
- get_upper_bound_condition_expr 
---------------------------------
- y.z < '6'::integer
-(1 row)
-
+y.z < '6'::integer
 select get_upper_bound_condition_expr('[ABEL,BAKER)'::textrange,'y.z');
-             get_upper_bound_condition_expr              
----------------------------------------------------------
- y.z COLLATE "default" < 'BAKER'::text COLLATE "default"
-(1 row)
-
+y.z COLLATE "default" < 'BAKER'::text COLLATE "default"
 select get_upper_bound_condition_expr('[ABEL,BAKER)'::textrange_c,'y.z');
-       get_upper_bound_condition_expr        
----------------------------------------------
- y.z COLLATE "C" < 'BAKER'::text COLLATE "C"
-(1 row)
-
+y.z COLLATE "C" < 'BAKER'::text COLLATE "C"
 select get_bounds_condition_expr('empty'::int4range);
- get_bounds_condition_expr 
----------------------------
- false
-(1 row)
-
+false
 select get_bounds_condition_expr('(,)'::int4range);
- get_bounds_condition_expr 
----------------------------
- true
-(1 row)
-
+true
 select get_bounds_condition_expr('(4,5]'::int4range);
-       get_bounds_condition_expr        
-----------------------------------------
- x >= '5'::integer and x < '6'::integer
-(1 row)
-
+x >= '5'::integer and x < '6'::integer
 select get_bounds_condition_expr('(4,5]'::int4range,'y.z');
-         get_bounds_condition_expr          
---------------------------------------------
- y.z >= '5'::integer and y.z < '6'::integer
-(1 row)
-
+y.z >= '5'::integer and y.z < '6'::integer
 select get_bounds_condition_expr('[4,5]'::int4range,'y.z');
-         get_bounds_condition_expr          
---------------------------------------------
- y.z >= '4'::integer and y.z < '6'::integer
-(1 row)
-
+y.z >= '4'::integer and y.z < '6'::integer
 select get_bounds_condition_expr('[4,5)'::int4range,'y.z');
-         get_bounds_condition_expr          
---------------------------------------------
- y.z >= '4'::integer and y.z < '5'::integer
-(1 row)
-
+y.z >= '4'::integer and y.z < '5'::integer
 select get_bounds_condition_expr('[4,5]'::int4range,'y.z');
-         get_bounds_condition_expr          
---------------------------------------------
- y.z >= '4'::integer and y.z < '6'::integer
-(1 row)
-
+y.z >= '4'::integer and y.z < '6'::integer
 select get_collation_expr(null::int4range);
- get_collation_expr 
---------------------
- 
-(1 row)
 
 select get_collation_expr(null::textrange);
- get_collation_expr 
---------------------
-  COLLATE "default"
-(1 row)
-
+ COLLATE "default"
 select get_collation_expr(null::textrange_c);
- get_collation_expr 
---------------------
-  COLLATE "C"
-(1 row)
-
+ COLLATE "C"
 select get_subtype_element_expr('(4,5]'::int4range);
- get_subtype_element_expr 
---------------------------
- x
-(1 row)
-
+x
 select get_subtype_element_expr('[ABEL,BAKER)'::textrange_c);
- get_subtype_element_expr 
---------------------------
- x COLLATE "C"
-(1 row)
-
+x COLLATE "C"
 select get_bound_expr(null::int4range,'4');
- get_bound_expr 
-----------------
- '4'::integer
-(1 row)
-
+'4'::integer
 select get_bound_expr(null::daterange,'1991-09-23');
-   get_bound_expr   
---------------------
- '1991-09-23'::date
-(1 row)
-
+'1991-09-23'::date
 select get_bound_expr(null::textrange,'ABEL');
-         get_bound_expr         
---------------------------------
- 'ABEL'::text COLLATE "default"
-(1 row)
-
+'ABEL'::text COLLATE "default"
 select get_bound_expr(null::textrange_c,'ABEL');
-      get_bound_expr      
---------------------------
- 'ABEL'::text COLLATE "C"
-(1 row)
-
-rollback;
+'ABEL'::text COLLATE "C"
+\i test/pgxntool/finish.sql
+SELECT finish();
+\echo # TRANSACTION INTENTIONALLY LEFT OPEN!
+# TRANSACTION INTENTIONALLY LEFT OPEN!

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,5 +1,5 @@
 \set ECHO none
-1..9
+1..12
 ok 1
 ok 2
 ok 3
@@ -9,6 +9,9 @@ ok 6 - element_range_comp('[10,100]'::int4range, 10)
 ok 7 - element_range_comp('[10,100]'::int4range, 110)
 ok 8 - is_singleton('[4,5)'::int4range)
 ok 9 - is_singleton('[4,5]'::int4range)
+ok 10 - get_collation_expr(null::int4range)
+ok 11 - get_collation_expr(null::textrange)
+ok 12 - get_collation_expr(null::textrange_c)
 select range_merge('[4,5]'::int4range,'[9,10]'::int4range);
 [4,11)
 select get_lower_bound_condition_expr('empty'::int4range);
@@ -49,12 +52,6 @@ select get_bounds_condition_expr('[4,5)'::int4range,'y.z');
 y.z >= '4'::integer and y.z < '5'::integer
 select get_bounds_condition_expr('[4,5]'::int4range,'y.z');
 y.z >= '4'::integer and y.z < '6'::integer
-select get_collation_expr(null::int4range);
-
-select get_collation_expr(null::textrange);
- COLLATE "default"
-select get_collation_expr(null::textrange_c);
- COLLATE "C"
 select get_subtype_element_expr('(4,5]'::int4range);
 x
 select get_subtype_element_expr('[ABEL,BAKER)'::textrange_c);

--- a/test/expected/date.out
+++ b/test/expected/date.out
@@ -1,0 +1,5 @@
+\set ECHO none
+1..2
+ok 1 - to_range from current_date +/- 1
+ok 2 - current_date +/- 1
+# TRANSACTION INTENTIONALLY LEFT OPEN!

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -1,0 +1,7 @@
+\set ECHO none
+1..4
+ok 1 - to_range from now() +/- 1us
+ok 2 - to_range from timezone test
+ok 3 - now() +/- 1us
+ok 4 - timezone test
+# TRANSACTION INTENTIONALLY LEFT OPEN!

--- a/test/expected/timestamptz.out
+++ b/test/expected/timestamptz.out
@@ -1,0 +1,7 @@
+\set ECHO none
+1..4
+ok 1 - to_range from now() +/- 1us
+ok 2 - to_range from timezone test
+ok 3 - now() +/- 1us
+ok 4 - timezone test
+# TRANSACTION INTENTIONALLY LEFT OPEN!

--- a/test/expected/zzz_build.out
+++ b/test/expected/zzz_build.out
@@ -1,0 +1,12 @@
+\set ECHO none
+            _range_from_array__create            
+-------------------------------------------------
+ range_from_array(integer[])
+ range_from_array(numeric[])
+ range_from_array(timestamp without time zone[])
+ range_from_array(timestamp with time zone[])
+ range_from_array(date[])
+ range_from_array(bigint[])
+(6 rows)
+
+# TRANSACTION INTENTIONALLY LEFT OPEN!

--- a/test/helpers/timestamp.sql
+++ b/test/helpers/timestamp.sql
@@ -1,0 +1,39 @@
+INSERT INTO test VALUES
+    ( 'now() +/- 1us'
+      , array[
+          now()
+          , now() + interval '1 us'
+          , now() - interval '1 us'
+        ]
+      , :range_type(
+          now():::subtype - interval '1 us'
+          , now():::subtype + interval '1 us'
+          , '[]'
+      )
+      , :range_type(
+          now():::subtype - interval '1 us'
+          , now():::subtype + interval '1 us'
+          , '[)'
+      )
+    )
+
+  , ( 'timezone test'
+      , array[
+          '2000-1-1'::timestamptz AT TIME ZONE 'CST6CDT'
+          , '2000-1-1'::timestamptz AT TIME ZONE 'MST7MDT'
+          , '2000-1-1'::timestamptz AT TIME ZONE 'EST5EDT'
+        ]
+      , :range_type(
+        '2000-1-1'::timestamptz AT TIME ZONE 'MST7MDT'
+        , '2000-1-1'::timestamptz AT TIME ZONE 'EST5EDT'
+        , '[]'
+      )
+      , :range_type(
+        '2000-1-1'::timestamptz AT TIME ZONE 'MST7MDT'
+        , '2000-1-1'::timestamptz AT TIME ZONE 'EST5EDT'
+        , '[)'
+      )
+    )
+;
+
+-- vi: expandtab ts=2 sw=2

--- a/test/helpers/type_run.sql
+++ b/test/helpers/type_run.sql
@@ -1,0 +1,26 @@
+SELECT plan(
+  0
+  + 2 * (SELECT count(*)::int FROM test)
+);
+
+SELECT is(
+    :install_schema.to_range(
+        expected_open
+        , lower(expected_open)
+        , upper(expected_open)
+    )
+    , expected_open
+    , 'to_range from ' || description
+  )
+  FROM test
+;
+
+SELECT is(
+    :install_schema.range_from_array(input)
+    , expected_closed
+    , description
+  )
+  FROM test
+;
+
+\i test/pgxntool/finish.sql

--- a/test/helpers/type_setup.sql
+++ b/test/helpers/type_setup.sql
@@ -1,0 +1,10 @@
+\i test/pgxntool/setup.sql
+
+CREATE TEMP TABLE test(
+  description text NOT NULL
+  , input :subtype[] NOT NULL
+  , expected_closed :range_type NOT NULL
+  , expected_open :range_type NOT NULL
+);
+
+

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -1,33 +1,70 @@
-begin;
 \set ECHO none
 
-\i sql/range_type_functions.sql
-\i sql/range_type_functions_94.sql
-
-\set ECHO all
+\i test/pgxntool/setup.sql
+SET search_path = :install_schema, tap;
+SELECT plan(
+    0
+    + 4 -- to_range
+    + 3 -- element_range_comp
+    + 2 -- is_singleton
+);
 
 create type textrange as range (subtype = text);
 create type textrange_c as range (subtype = text, collation = "C");
 
 set datestyle = 'ISO';
 
-select to_range(4,5,'[]',null::int4range);
+select is(
+    to_range(null::int4range, 4,5,'[]')
+    , '[4,5]'::int4range
+);
 
-select to_range('2015-01-01'::date,'2016-01-1','[)',null::daterange);
+select is(
+    to_range(null::daterange, '2015-01-01'::date,'2016-01-1')
+    , '[2015-1-1,2016-1-1)'::daterange
+);
 
-select to_range(4,null::int4range);
+select is(
+    to_range(null::int4range, 4)
+    , '[4,4]'::int4range
+);
 
-select to_range('2015-01-01'::date,null::daterange);
+select is(
+    to_range(null::daterange, '2015-01-01'::date)
+    , '[2015-1-1,2015-1-1]'::daterange
+);
 
-select element_range_comp(4,'[10,100]'::int4range);
+select is(
+    element_range_comp('[10,100]'::int4range, 4)
+    , -1::smallint
+    , $$element_range_comp('[10,100]'::int4range, 4)$$
+);
 
-select element_range_comp(10,'[10,100]'::int4range);
+select is(
+    element_range_comp('[10,100]'::int4range, 10)
+    , 0::smallint
+    , $$element_range_comp('[10,100]'::int4range, 10)$$
+);
 
-select element_range_comp(110,'[10,100]'::int4range);
+select is(
+    element_range_comp('[10,100]'::int4range, 110)
+    , 1::smallint
+    , $$element_range_comp('[10,100]'::int4range, 110)$$
+);
 
-select is_singleton('[4,5)'::int4range);
+select is(
+    is_singleton('[4,5)'::int4range)
+    , true
+    , $$is_singleton('[4,5)'::int4range)$$
+);
 
-select is_singleton('[4,5]'::int4range);
+select is(
+    is_singleton('[4,5]'::int4range)
+    , false
+    , $$is_singleton('[4,5]'::int4range)$$
+);
+
+\set ECHO ALL
 
 select range_merge('[4,5]'::int4range,'[9,10]'::int4range);
 
@@ -64,4 +101,4 @@ select get_bound_expr(null::daterange,'1991-09-23');
 select get_bound_expr(null::textrange,'ABEL');
 select get_bound_expr(null::textrange_c,'ABEL');
 
-rollback;
+\i test/pgxntool/finish.sql

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -7,6 +7,7 @@ SELECT plan(
     + 4 -- to_range
     + 3 -- element_range_comp
     + 2 -- is_singleton
+    + 3 -- get_collation_expr
 );
 
 create type textrange as range (subtype = text);
@@ -64,6 +65,22 @@ select is(
     , $$is_singleton('[4,5]'::int4range)$$
 );
 
+select is(
+    get_collation_expr(null::int4range)
+    , NULL
+    , $$get_collation_expr(null::int4range)$$
+);
+select is(
+    get_collation_expr(null::textrange)
+    , ' COLLATE "default"'
+    , $$get_collation_expr(null::textrange)$$
+);
+select is(
+    get_collation_expr(null::textrange_c)
+    , ' COLLATE "C"'
+    , $$get_collation_expr(null::textrange_c)$$
+);
+
 \set ECHO ALL
 
 select range_merge('[4,5]'::int4range,'[9,10]'::int4range);
@@ -87,11 +104,6 @@ select get_bounds_condition_expr('(4,5]'::int4range,'y.z');
 select get_bounds_condition_expr('[4,5]'::int4range,'y.z');
 select get_bounds_condition_expr('[4,5)'::int4range,'y.z');
 select get_bounds_condition_expr('[4,5]'::int4range,'y.z');
-
-select get_collation_expr(null::int4range);
-select get_collation_expr(null::textrange);
-select get_collation_expr(null::textrange_c);
-
 
 select get_subtype_element_expr('(4,5]'::int4range);
 select get_subtype_element_expr('[ABEL,BAKER)'::textrange_c);

--- a/test/sql/date.sql
+++ b/test/sql/date.sql
@@ -1,0 +1,34 @@
+\set ECHO none
+
+\set range_type tsrange
+\set subtype timestamp
+\i test/helpers/type_setup.sql
+
+INSERT INTO test VALUES
+    ( 'current_date +/- 1'
+      , array[
+          current_date
+          , current_date + 1
+          , current_date + 1
+          , current_date + 1
+          , current_date - 1
+          , current_date - 1
+          , current_date - 1
+        ]
+      , :range_type(
+          current_date - 1
+          , current_date + 1
+          , '[]'
+      )
+      , :range_type(
+          current_date - 1
+          , current_date + 1
+          , '[)'
+      )
+    )
+;
+
+
+\i test/helpers/type_run.sql
+
+-- vi: expandtab ts=2 sw=2

--- a/test/sql/timestamp.sql
+++ b/test/sql/timestamp.sql
@@ -1,0 +1,11 @@
+\set ECHO none
+
+\set range_type tsrange
+\set subtype timestamp
+\i test/helpers/type_setup.sql
+
+\i test/helpers/timestamp.sql
+
+\i test/helpers/type_run.sql
+
+-- vi: expandtab ts=2 sw=2

--- a/test/sql/timestamptz.sql
+++ b/test/sql/timestamptz.sql
@@ -1,0 +1,11 @@
+\set ECHO none
+
+\set range_type tstzrange
+\set subtype timestamptz
+\i test/helpers/type_setup.sql
+
+\i test/helpers/timestamp.sql
+
+\i test/helpers/type_run.sql
+
+-- vi: expandtab ts=2 sw=2

--- a/test/sql/zzz_build.sql
+++ b/test/sql/zzz_build.sql
@@ -1,0 +1,11 @@
+\set ECHO none
+
+\i test/pgxntool/psql.sql
+
+BEGIN;
+-- NOTE! This is NOT the .sql file!
+\i sql/range_type_functions.sql
+
+\echo # TRANSACTION INTENTIONALLY LEFT OPEN!
+
+-- vi: expandtab sw=2 ts=2


### PR DESCRIPTION
Adds view range_types.

Adds `_range_from_array__create()`, which creates a `range_from_array()` function for the specified type.

Creates `range_from_array()` functions for types installed in pg_catalog.

Changes parameter order for `to_range()` and `element_range_comp()`.

Sets default bounds of '[)' on `to_range()`.

Adds tests for `range_from_array()`, and a specific test for installing from SQL (useful for debugging syntax errors).

Switch some of the tests in base.sql to using pgTap.